### PR TITLE
Dockerized build and flash process

### DIFF
--- a/BuilderDockerfile.amd64
+++ b/BuilderDockerfile.amd64
@@ -1,0 +1,12 @@
+FROM ubuntu:18.04
+RUN apt-get update && \
+    apt-get install -y software-properties-common make && \
+    add-apt-repository ppa:team-gcc-arm-embedded/ppa && \
+    apt-get update && \
+    apt-get install -y gcc-arm-none-eabi
+
+VOLUME /sources
+WORKDIR /sources
+
+RUN echo "cd \$1 && make \$2" > /entrypoint.sh
+ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/FlasherDockerfile.amd64
+++ b/FlasherDockerfile.amd64
@@ -1,0 +1,6 @@
+FROM alpine:latest
+RUN apk update && \
+    apk add stlink
+
+VOLUME /binaries
+ENTRYPOINT ["st-flash", "write", "/binaries/ch.bin", "0x8000000"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+SOURCE_DIR=$(PWD)/ChibiOS_18.2.1
+MAKEFILE_DIR=demos/STM32/RT-STM32F407-DISCOVERY
+help: ## === Tools for building and deploying firmware to STM32F407Discovery board ===
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+
+.PHONY: builder
+builder: ## Build the stm_builder:latest image for software complation
+	mkdir -p dummy_context
+	docker build -f BuilderDockerfile.amd64 -t stm_builder:latest dummy_context
+	rmdir dummy_context
+
+.PHONY: flasher
+flasher: ## Build the stm_flasher:latest image for binary flashing
+	mkdir -p dummy_context
+	docker build -f FlasherDockerfile.amd64 -t stm_flasher:latest dummy_context
+	rmdir dummy_context
+
+.PHONY: run_build
+run_build: ## Run the compilation by means of image created by `make builder`
+	docker run --rm -v $(SOURCE_DIR):/sources stm_builder:latest $(MAKEFILE_DIR)
+
+.PHONY: run_flash
+run_flash: ## Flash the firmware by means of image created by `make flasher`
+	docker run --rm --privileged -v /dev/bus/usb:/dev/bus/usb -v $(SOURCE_DIR)/$(MAKEFILE_DIR)/build:/binaries stm_flasher:latest
+
+.PHONY: clean
+clean: ## Remove the build
+	docker run --rm -v $(SOURCE_DIR):/sources stm_builder:latest $(MAKEFILE_DIR) clean
+
+## all: Build images, build firmware, flash firmware
+all: builder flasher run_build run_flash

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,12 @@ flasher: ## Build the stm_flasher:latest image for binary flashing
 	docker build -f FlasherDockerfile.amd64 -t stm_flasher:latest dummy_context
 	rmdir dummy_context
 
-.PHONY: run_build
-run_build: ## Run the compilation by means of image created by `make builder`
+.PHONY: build
+build: ## Run the compilation by means of image created by `make builder`
 	docker run --rm -v $(SOURCE_DIR):/sources stm_builder:latest $(MAKEFILE_DIR)
 
-.PHONY: run_flash
-run_flash: ## Flash the firmware by means of image created by `make flasher`
+.PHONY: flash
+flash: ## Flash the firmware by means of image created by `make flasher`
 	docker run --rm --privileged -v /dev/bus/usb:/dev/bus/usb -v $(SOURCE_DIR)/$(MAKEFILE_DIR)/build:/binaries stm_flasher:latest
 
 .PHONY: clean
@@ -28,4 +28,4 @@ clean: ## Remove the build
 	docker run --rm -v $(SOURCE_DIR):/sources stm_builder:latest $(MAKEFILE_DIR) clean
 
 ## all: Build images, build firmware, flash firmware
-all: builder flasher run_build run_flash
+all: builder flasher build flash

--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@ Replacement for BeagleBone to handle readings from car's non-driverless sensors.
 
 `STM32CubeMX-app` application for setting up initial STM32 configuration
 `STM32F407VGTx` stuff related to our microcontroller - documents and CubeMX project file
+
+## Getting it working
+Utilizing Makefile in root directory. Help output is available, free to run `make` and read it.
+* Build all tools, firmware and flash: `make all`
+* Create docker images for building and flashing firmware: `make builder && make flasher`
+* Build firmware (given you have corresponding docker image): `make run_build`
+* Flash firmware `make run_flash`
+
+To build flash something specific - modify the Makefile variables

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Replacement for BeagleBone to handle readings from car's non-driverless sensors.
 Utilizing Makefile in root directory. Help output is available, free to run `make` and read it.
 * Build all tools, firmware and flash: `make all`
 * Create docker images for building and flashing firmware: `make builder && make flasher`
-* Build firmware (given you have corresponding docker image): `make run_build`
-* Flash firmware `make run_flash`
+* Build firmware (given you have corresponding docker image): `make build`
+* Flash firmware `make flash`
 
 To build flash something specific - modify the Makefile variables


### PR DESCRIPTION
Since ubuntu does not have st-link in repositories and alpine does not have `arm-none-eabi` in repositories - using 2 separate images. The whole process is not dockerized and added to Makefile for easy deployment